### PR TITLE
fixup!sepolicy: Introduce automated DC Dimming [3/3]

### DIFF
--- a/common/private/file.te
+++ b/common/private/file.te
@@ -3,4 +3,4 @@ type adbroot_data_file, file_type, data_file_type, core_data_file_type;
 type pocket_judge_sysfs, fs_type, sysfs_type;
 
 # DC Dimming
-type sysfs_dc_dim, fs_type, sysfs_type;
+type vendor_sysfs_dc_dim, fs_type, sysfs_type;

--- a/common/private/platform_app.te
+++ b/common/private/platform_app.te
@@ -34,3 +34,6 @@ allow platform_app sysfs_thermal:file r_file_perms;
 # Allow Launcher3 to access zram
 allow platform_app sysfs_zram:dir search;
 allow platform_app sysfs_zram:file r_file_perms;
+
+# DC Dimming
+allow platform_app vendor_sysfs_dc_dim:file rw_file_perms;

--- a/common/private/priv_app.te
+++ b/common/private/priv_app.te
@@ -4,3 +4,6 @@ allow priv_app theme_prop:file { read open };
 get_prop(priv_app, theme_prop)
 
 allow priv_app sysfs_dc_dim:file rw_file_perms;
+
+# DC Dimming
+allow priv_app vendor_sysfs_dc_dim:file rw_file_perms;

--- a/common/private/system_server.te
+++ b/common/private/system_server.te
@@ -7,7 +7,7 @@ allow system_server pocket_service:service_manager { add find };
 allow system_server app_zygote:process getpgid;
 
 # DC Dimming
-allow system_server sysfs_dc_dim:file rw_file_perms;
+allow system_server vendor_sysfs_dc_dim:file rw_file_perms;
 add_service(system_server, dc_dimming_service);
 
 # App Lock


### PR DESCRIPTION
* Label sysfs node as sysfs_dc_dim in device tree

Change-Id: Ic50a616037dc744943ca1a7c04c506827ef50526