### PR TITLE
sepolicy: Allow Launcher3 to access zram

### DIFF
--- a/common/private/platform_app.te
+++ b/common/private/platform_app.te
@@ -15,3 +15,7 @@ hal_client_domain(platform_app, hal_lineage_touch)
 
 # Allow externalstorage access
 allow platform_app mnt_pass_through_file:dir { create_dir_perms mounton };
+
+# Allow Launcher3 to access zram
+allow platform_app sysfs_zram:dir search;
+allow platform_app sysfs_zram:file r_file_perms;


### PR DESCRIPTION
avc: denied { search } for name="zram0" dev="sysfs" ino=71149 scontext=u:r:platform_app:s0:c512,c768 tcontext=u:object_r:sysfs_zram:s0 tclass=dir permissive=1 app=com.android.launcher3

avc: denied { read } for name="mm_stat" dev="sysfs" ino=71175 scontext=u:r:platform_app:s0:c512,c768 tcontext=u:object_r:sysfs_zram:s0 tclass=file permissive=1 app=com.android.launcher3

avc: denied { open } for path="/sys/devices/virtual/block/zram0/mm_stat" dev="sysfs" ino=71175 scontext=u:r:platform_app:s0:c512,c768 tcontext=u:object_r:sysfs_zram:s0 tclass=file permissive=1 app=com.android.launcher3

avc: denied { getattr } for path="/sys/devices/virtual/block/zram0/mm_stat" dev="sysfs" ino=71175 scontext=u:r:platform_app:s0:c512,c768 tcontext=u:object_r:sysfs_zram:s0 tclass=file permissive=1 app=com.android.launcher3